### PR TITLE
Refactor callbacks bases

### DIFF
--- a/src/uetai/callbacks/__init__.py
+++ b/src/uetai/callbacks/__init__.py
@@ -1,4 +1,5 @@
 """init public callbacks"""
 from .image_monitor import ImageMonitorBase
+from .text_monitor import TextMonitorBase
 
-__all__ = ["ImageMonitorBase"]
+__all__ = ["ImageMonitorBase", "TextMonitorBase"]

--- a/src/uetai/callbacks/text_monitor.py
+++ b/src/uetai/callbacks/text_monitor.py
@@ -1,0 +1,55 @@
+from typing import Any, Optional
+
+import pytorch_lightning as pl
+from pytorch_lightning import Callback
+
+from uetai.callbacks.utils import trainer_finish_run
+
+
+class TextMonitorBase(Callback):
+    def __init__(self):
+        pass
+
+    def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        pass
+
+    def on_train_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int,
+    ) -> None:
+        pass
+
+    def on_train_epoch_end(
+        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", unused: Optional = None
+    ) -> None:
+        pass
+
+    def on_validation_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int,
+    ) -> None:
+        pass
+
+    def on_validation_epoch_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        pass
+
+    def on_keyboard_interrupt(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        trainer_finish_run(trainer=trainer)
+
+    def add_text(self):
+        """Override function to customize task"""
+        pass
+
+    def _add_text(self):
+        """Log text as HTML to Weight & Biases dashboard."""
+        pass

--- a/src/uetai/callbacks/utils.py
+++ b/src/uetai/callbacks/utils.py
@@ -1,0 +1,28 @@
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.utilities import rank_zero_warn
+
+from uetai.logger import SummaryWriter
+
+
+def check_logger(logger: LightningLoggerBase) -> bool:
+    available = True
+    msg = None
+    if not logger:
+        msg = "Trainer has no logger. Cannot log media."
+        available = False
+    elif isinstance(logger, SummaryWriter):
+        if 'wandb' not in logger.log_tool:
+            msg = "`Summary_Writer` is not logging with `wandb`. Please set `WANDB_API_KEY` to start using `wandb`"
+    else:
+        msg = f"Except logger is `SummaryWriter` type, receive {logger.__class__.__name__}"
+        available = False
+    rank_zero_warn(msg)
+    return available
+
+
+def trainer_finish_run(trainer: "pl.Trainer") -> None:
+    logger = trainer.logger
+    if isinstance(logger, SummaryWriter):
+        if 'wandb' in logger.log_tool:
+            logger.wandb_run.finish()

--- a/src/uetai/logger/general.py
+++ b/src/uetai/logger/general.py
@@ -1,7 +1,4 @@
 """uetai utilities"""
-import sys
-import subprocess
-import argparse
 import socket
 import platform
 from pathlib import Path

--- a/src/uetai/logger/summary_writer.py
+++ b/src/uetai/logger/summary_writer.py
@@ -20,6 +20,7 @@ from pytorch_lightning.loggers import (
     LightningLoggerBase
 )
 
+import uetai
 from uetai.logger.general import colorstr
 
 try:

--- a/src/uetai/utils/__init__.py
+++ b/src/uetai/utils/__init__.py
@@ -1,0 +1,4 @@
+"""init public class"""
+from .warning import warn_missing_pkg
+
+__all__ = ["warn_missing_pkg"]

--- a/src/uetai/utils/warning.py
+++ b/src/uetai/utils/warning.py
@@ -1,0 +1,41 @@
+# https://github.com/PyTorchLightning/lightning-bolts
+import os
+import warnings
+from typing import Callable, Dict, Optional
+
+MISSING_PACKAGE_WARNINGS: Dict[str, int] = {}
+
+WARN_MISSING_PACKAGE = int(os.environ.get("WARN_MISSING_PACKAGE", False))
+
+
+def warn_missing_pkg(
+        pkg_name: str,
+        pypi_name: Optional[str] = None,
+        extra_text: Optional[str] = None,
+        stdout_func: Callable = warnings.warn,
+) -> int:
+    """Template for warning on missing packages, show them just once.
+    Args:
+        pkg_name: Name of missing package
+        pypi_name: In case that package name differ from PyPI name
+        extra_text: Additional text after the base warning
+        stdout_func: Define used function for streaming warning, use ``warnings.warn`` or ``logging.warning``
+    Returns:
+        Number of warning calls
+    """
+    if not WARN_MISSING_PACKAGE:
+        return -1
+
+    if pkg_name not in MISSING_PACKAGE_WARNINGS:
+        extra_text = os.linesep + extra_text if extra_text else ""
+        if not pypi_name:
+            pypi_name = pkg_name
+        stdout_func(
+            f"You want to use `{pkg_name}` which is not installed yet,"
+            f" install it with `pip install {pypi_name}`." + extra_text
+        )
+        MISSING_PACKAGE_WARNINGS[pkg_name] = 1
+    else:
+        MISSING_PACKAGE_WARNINGS[pkg_name] += 1
+
+    return MISSING_PACKAGE_WARNINGS[pkg_name]


### PR DESCRIPTION
**Before PR**
Image callback base (`ImageMonitorBase`) was specified for the classification task, not for the image template in general

**Submitting**
- [ ] Divide `ImageMonitorBase` into a image callback template and a classification task callbacks
- [ ] Adding `TextMonitorBase` 
- [ ] Adding callbacks utilities in `callbacks.utils`
